### PR TITLE
cache loaded remote schema 

### DIFF
--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -307,10 +307,10 @@ func TestLoadFromRemoteURL(t *testing.T) {
 
 	loader := openapi3.NewSwaggerLoader()
 	loader.IsExternalRefsAllowed = true
-	url, err := url.Parse("http://" + addr + "/test.openapi.json")
+	remote, err := url.Parse("http://" + addr + "/test.openapi.json")
 	require.NoError(t, err)
 
-	swagger, err := loader.LoadSwaggerFromURI(url)
+	swagger, err := loader.LoadSwaggerFromURI(remote)
 	require.NoError(t, err)
 
 	require.Equal(t, "string", swagger.Components.Schemas["TestSchema"].Value.Type)
@@ -422,4 +422,35 @@ func TestLoadYamlFileWithExternalSchemaRef(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, swagger.Components.Schemas["AnotherTestSchema"].Value.Type)
+}
+
+type hitCntFS struct {
+	fs   http.Dir
+	hits map[string]int
+}
+
+func (fs hitCntFS) Open(fn string) (http.File, error) {
+	fs.hits[fn] = fs.hits[fn] + 1
+	return fs.fs.Open(fn)
+}
+
+func TestRemoteURLCaching(t *testing.T) {
+
+	sfs := hitCntFS{fs: "testdata", hits: map[string]int{}}
+	fs := http.FileServer(sfs)
+	ts := createTestServer(fs)
+	ts.Start()
+	defer ts.Close()
+
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	remote, err := url.Parse("http://" + addr + "/test.refcache.openapi.yml")
+	require.NoError(t, err)
+
+	_, err = loader.LoadSwaggerFromURI(remote)
+	require.NoError(t, err)
+
+	require.Contains(t, sfs.hits, "/test.refcache.openapi.yml")
+	require.Contains(t, sfs.hits, "/components.openapi.yml")
+	require.Equal(t, 1, sfs.hits["http://localhost:7965/components.openapi.yml"], "expcting 1 load of referenced schema")
 }

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -184,10 +184,10 @@ func TestResolveSchemaExternalRef(t *testing.T) {
 			},
 		},
 	}
-	loader := &openapi3.SwaggerLoader{
-		IsExternalRefsAllowed:  true,
-		LoadSwaggerFromURIFunc: multipleSourceLoader.LoadSwaggerFromURI,
-	}
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	loader.LoadSwaggerFromURIFunc = multipleSourceLoader.LoadSwaggerFromURI
+
 	doc, err := loader.LoadSwaggerFromURI(rootLocation)
 	require.NoError(t, err)
 	err = doc.Validate(loader.Context)
@@ -452,5 +452,5 @@ func TestRemoteURLCaching(t *testing.T) {
 
 	require.Contains(t, sfs.hits, "/test.refcache.openapi.yml")
 	require.Contains(t, sfs.hits, "/components.openapi.yml")
-	require.Equal(t, 1, sfs.hits["http://localhost:7965/components.openapi.yml"], "expcting 1 load of referenced schema")
+	require.Equal(t, 1, sfs.hits["/components.openapi.yml"], "expcting 1 load of referenced schema")
 }

--- a/openapi3/testdata/test.refcache.openapi.yml
+++ b/openapi3/testdata/test.refcache.openapi.yml
@@ -1,0 +1,15 @@
+---
+openapi: 3.0.0
+info:
+  title: 'OAI Specification w/ refs in YAML. Multiple refs to the same remote schema'
+  version: '1'
+paths: {}
+components:
+  schemas:
+    AnotherTestSchema:
+      type: object
+      properties:
+        ref1:
+          "$ref": http://localhost:7965/components.openapi.yml#/components/schemas/CustomTestSchema
+        ref2:
+          "$ref": http://localhost:7965/components.openapi.yml#/components/schemas/Name


### PR DESCRIPTION
when resolving components for loaded schemas and when external resolution is enabled, 
kin-openapi will read the remote schema, parse it and resolve it in order to satisfy the reference attribute in the calling schema, but it does so every time a reference needs resolving leading
to unnecessary network traffic request for the same remote schema.

For example:
```yaml
components:
  schemas:
    AnotherTestSchema:
      type: object
      properties:
        ref1:
          "$ref": http://localhost:7965/components.openapi.yml#/components/schemas/CustomTestSchema
        ref2:
          "$ref": http://localhost:7965/components.openapi.yml#/components/schemas/Name
```

In the above case, external resolution for components.openapi.yml is performed when parsing the
fragment above only to be done again for ref2. This is recursive and if components.openapi.yml
includes other references they are resolved the same way.

This very quickly leads to major network traffic which at the very least is unnecessary.

This pull request caches the loaded schemas in the swagger loader and returns resolved schemas from the cache once they are loaded.

Added tests to ensure the schemas are loaded only once.

