### PR TITLE
Fix/add metadata - do NOT UPSTREAM this

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.11.x
+- 1.12.x
 env:
   global:
   - GO111MODULE: 'on'

--- a/openapi3/encoding.go
+++ b/openapi3/encoding.go
@@ -9,6 +9,7 @@ import (
 
 // Encoding is specified by OpenAPI/Swagger 3.0 standard.
 type Encoding struct {
+	Metadata
 	ExtensionProps
 
 	ContentType   string                `json:"contentType,omitempty"`

--- a/openapi3/examples.go
+++ b/openapi3/examples.go
@@ -6,6 +6,7 @@ import (
 
 // Example is specified by OpenAPI/Swagger 3.0 standard.
 type Example struct {
+	Metadata
 	ExtensionProps
 
 	Summary       string      `json:"summary,omitempty"`

--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Header struct {
+	Metadata
 	ExtensionProps
 
 	// Optional description. Should use CommonMark syntax.

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -8,6 +8,7 @@ import (
 
 // Link is specified by OpenAPI/Swagger standard version 3.0.
 type Link struct {
+	Metadata
 	ExtensionProps
 	Description string                 `json:"description,omitempty"`
 	Href        string                 `json:"href,omitempty"`

--- a/openapi3/metadata.go
+++ b/openapi3/metadata.go
@@ -1,0 +1,8 @@
+package openapi3
+
+import "net/url"
+
+type Metadata struct {
+	ID   string  `json:"-"`
+	Path url.URL `json:"-"`
+}

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -9,6 +9,7 @@ import (
 
 // Operation represents "operation" specified by" OpenAPI/Swagger 3.0 standard.
 type Operation struct {
+	Metadata
 	ExtensionProps
 
 	// Optional tags for documentation.

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -50,6 +50,7 @@ func (parameters Parameters) Validate(c context.Context) error {
 
 // Parameter is specified by OpenAPI/Swagger 3.0 standard.
 type Parameter struct {
+	Metadata
 	ExtensionProps
 	Name            string                 `json:"name,omitempty"`
 	In              string                 `json:"in,omitempty"`

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
@@ -9,6 +10,10 @@ import (
 type CallbackRef struct {
 	Ref   string
 	Value *Callback
+}
+
+func (value CallbackRef) String() string {
+	return fmt.Sprintf("%s:CallbackRef", value.Ref)
 }
 
 func (value *CallbackRef) MarshalJSON() ([]byte, error) {
@@ -32,6 +37,16 @@ type ExampleRef struct {
 	Value *Example
 }
 
+func (value ExampleRef) String() string {
+	return fmt.Sprintf("%s:ExampleRef", value.Ref)
+}
+
+func (value ExampleRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value ExampleRef) IsRef() bool    { return value.Ref != "" }
+func (value ExampleRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
+func (value ExampleRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
+func (value ExampleRef) EmptyRef() bool { return value.Ref == "" }
+
 func (value *ExampleRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
 }
@@ -48,6 +63,16 @@ type HeaderRef struct {
 	Ref   string
 	Value *Header
 }
+
+func (value HeaderRef) String() string {
+	return fmt.Sprintf("%s:HeaderRef", value.Ref)
+}
+
+func (value HeaderRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value HeaderRef) IsRef() bool    { return value.Ref != "" }
+func (value HeaderRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
+func (value HeaderRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
+func (value HeaderRef) EmptyRef() bool { return value.Ref == "" }
 
 func (value *HeaderRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -70,6 +95,16 @@ type LinkRef struct {
 	Value *Link
 }
 
+func (value LinkRef) String() string {
+	return fmt.Sprintf("%s:LinkRef", value.Ref)
+}
+
+func (value LinkRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value LinkRef) IsRef() bool    { return value.Ref != "" }
+func (value LinkRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
+func (value LinkRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
+func (value LinkRef) EmptyRef() bool { return value.Ref == "" }
+
 func (value *LinkRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
 }
@@ -90,6 +125,16 @@ type ParameterRef struct {
 	Ref   string
 	Value *Parameter
 }
+
+func (value ParameterRef) String() string {
+	return fmt.Sprintf("%s:ParameterRef", value.Ref)
+}
+
+func (value ParameterRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value ParameterRef) IsRef() bool    { return value.Ref != "" }
+func (value ParameterRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
+func (value ParameterRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
+func (value ParameterRef) EmptyRef() bool { return value.Ref == "" }
 
 func (value *ParameterRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -112,6 +157,16 @@ type ResponseRef struct {
 	Value *Response
 }
 
+func (value ResponseRef) String() string {
+	return fmt.Sprintf("%s:ResponseRef", value.Ref)
+}
+
+func (value ResponseRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value ResponseRef) IsRef() bool    { return value.Ref != "" }
+func (value ResponseRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
+func (value ResponseRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
+func (value ResponseRef) EmptyRef() bool { return value.Ref == "" }
+
 func (value *ResponseRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
 }
@@ -133,6 +188,16 @@ type RequestBodyRef struct {
 	Value *RequestBody
 }
 
+func (value RequestBodyRef) String() string {
+	return fmt.Sprintf("%s:RequestBodyRef", value.Ref)
+}
+
+func (value RequestBodyRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value RequestBodyRef) IsRef() bool    { return value.Ref != "" }
+func (value RequestBodyRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
+func (value RequestBodyRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
+func (value RequestBodyRef) EmptyRef() bool { return value.Ref == "" }
+
 func (value *RequestBodyRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
 }
@@ -153,6 +218,16 @@ type SchemaRef struct {
 	Ref   string
 	Value *Schema
 }
+
+func (value SchemaRef) String() string {
+	return fmt.Sprintf("%s:SchemaRef", value.Ref)
+}
+
+func (value SchemaRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value SchemaRef) IsRef() bool    { return value.Ref != "" }
+func (value SchemaRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
+func (value SchemaRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
+func (value SchemaRef) EmptyRef() bool { return value.Ref == "" }
 
 func NewSchemaRef(ref string, value *Schema) *SchemaRef {
 	return &SchemaRef{
@@ -181,6 +256,16 @@ type SecuritySchemeRef struct {
 	Ref   string
 	Value *SecurityScheme
 }
+
+func (value SecuritySchemeRef) String() string {
+	return fmt.Sprintf("%s:SecuritySchemeRef", value.Ref)
+}
+
+func (value SecuritySchemeRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value SecuritySchemeRef) IsRef() bool    { return value.Ref != "" }
+func (value SecuritySchemeRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
+func (value SecuritySchemeRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
+func (value SecuritySchemeRef) EmptyRef() bool { return value.Ref == "" }
 
 func (value *SecuritySchemeRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -8,6 +8,7 @@ import (
 
 // RequestBody is specified by OpenAPI/Swagger 3.0 standard.
 type RequestBody struct {
+	Metadata
 	ExtensionProps
 	Description string  `json:"description,omitempty"`
 	Required    bool    `json:"required,omitempty"`

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -33,6 +33,7 @@ func (responses Responses) Validate(c context.Context) error {
 
 // Response is specified by OpenAPI/Swagger 3.0 standard.
 type Response struct {
+	Metadata
 	ExtensionProps
 	Description string                `json:"description,omitempty"`
 	Headers     map[string]*HeaderRef `json:"headers,omitempty"`

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -47,6 +47,7 @@ func Uint64Ptr(value uint64) *uint64 {
 
 // Schema is specified by OpenAPI/Swagger 3.0 standard.
 type Schema struct {
+	Metadata
 	ExtensionProps
 
 	OneOf        []*SchemaRef  `json:"oneOf,omitempty"`

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -9,6 +9,7 @@ import (
 )
 
 type SecurityScheme struct {
+	Metadata
 	ExtensionProps
 
 	Type         string      `json:"type,omitempty"`
@@ -140,6 +141,7 @@ func (ss *SecurityScheme) Validate(c context.Context) error {
 }
 
 type OAuthFlows struct {
+	Metadata
 	ExtensionProps
 	Implicit          *OAuthFlow `json:"implicit,omitempty"`
 	Password          *OAuthFlow `json:"password,omitempty"`
@@ -181,6 +183,7 @@ func (flows *OAuthFlows) Validate(c context.Context) error {
 }
 
 type OAuthFlow struct {
+	Metadata
 	ExtensionProps
 	AuthorizationURL string            `json:"authorizationUrl,omitempty"`
 	TokenURL         string            `json:"tokenUrl,omitempty"`

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Swagger struct {
+	Metadata `json:"-"`
 	ExtensionProps
 	OpenAPI      string               `json:"openapi"` // Required
 	Info         Info                 `json:"info"`    // Required

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"reflect"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -29,6 +30,7 @@ type SwaggerLoader struct {
 	IsExternalRefsAllowed  bool
 	Context                context.Context
 	LoadSwaggerFromURIFunc func(loader *SwaggerLoader, url *url.URL) (*Swagger, error)
+	visited                map[string]struct{}
 	loadedRemoteSchemas    map[string]*Swagger
 }
 
@@ -104,6 +106,12 @@ func (swaggerLoader *SwaggerLoader) LoadSwaggerFromDataWithPath(data []byte, pat
 }
 
 func (swaggerLoader *SwaggerLoader) ResolveRefsIn(swagger *Swagger, path *url.URL) (err error) {
+	swaggerLoader.visited = make(map[string]struct{})
+
+	// first pass - mark each resource with its id and path
+	if err = swaggerLoader.fixMetadata(swagger, path); err != nil {
+		return
+	}
 
 	// Visit all components
 	components := swagger.Components
@@ -158,6 +166,7 @@ func (swaggerLoader *SwaggerLoader) ResolveRefsIn(swagger *Swagger, path *url.UR
 				if err = swaggerLoader.resolveParameterRef(swagger, parameter, path); err != nil {
 					return
 				}
+
 			}
 			if requestBody := operation.RequestBody; requestBody != nil {
 				if err = swaggerLoader.resolveRequestBodyRef(swagger, requestBody, path); err != nil {
@@ -175,129 +184,96 @@ func (swaggerLoader *SwaggerLoader) ResolveRefsIn(swagger *Swagger, path *url.UR
 	return
 }
 
-func copyURL(basePath *url.URL) (*url.URL, error) {
-	return url.Parse(basePath.String())
+func (swaggerLoader *SwaggerLoader) fixMetadata(swagger *Swagger, path *url.URL) (err error) {
+	comps := reflect.ValueOf(swagger.Components)
+	const compPfx = "/components"
+	var p url.URL
+
+	if path != nil {
+		p = *path
+	}
+
+	swagger.Metadata.ID = p.Path
+	swagger.Metadata.Path = p
+
+	for i := 0; i < comps.NumField(); i++ {
+
+		fn := comps.Type().Field(i).Name
+		f := comps.Field(i)
+		if f.Kind() != reflect.Map {
+			continue
+		}
+
+		p.Fragment = strings.ToLower(fmt.Sprintf("%s/%s", compPfx, fn))
+
+		if err := swaggerLoader.fixComponentMetadata(f, swagger, p); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-func mergeComponents(c1, c2 Components) Components {
-	if c2.Schemas != nil && c1.Schemas == nil {
-		c1.Schemas = c2.Schemas
-	} else {
-		for k, v := range c2.Schemas {
-			if v1, ok := c1.Schemas[k]; ok {
-				if v1.Ref == "" && v.Ref != "" {
-					continue // keep the resolved ones
-				}
-			}
-			c1.Schemas[k] = v
-		}
+func (swaggerLoader *SwaggerLoader) fixComponentMetadata(comp reflect.Value, swagger *Swagger, p url.URL) error {
+	if comp.Kind() != reflect.Map {
+		return fmt.Errorf("expecting collection to be a map: %v", comp)
 	}
-	if c2.Parameters != nil && c1.Parameters == nil {
-		c1.Parameters = c2.Parameters
-	} else {
-		for k, v := range c2.Parameters {
-			if v1, ok := c1.Parameters[k]; ok {
-				if v1.Ref == "" && v.Ref != "" {
-					continue // keep the resolved ones
-				}
-			}
-			c1.Parameters[k] = v
+
+	mi := comp.MapRange()
+	for mi.Next() {
+		k := mi.Key()
+		v := mi.Value()
+
+		if k.Kind() != reflect.String {
+			return fmt.Errorf("expecting collection to be a map with string k: %v", k)
 		}
+
+		if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+			return fmt.Errorf("expecting collection to be a map with value that is a pointer to struct: (k: %s) %v", k, v)
+		}
+
+		// get `Ref` , Value` fields
+		rf := v.Elem().FieldByName("Ref")
+		v = v.Elem().FieldByName("Value")
+
+		if !v.IsValid() {
+			return fmt.Errorf("expecting collection to be a map value to be a pointer to Ref type with a `Value` field: (k: %s) %v", k, v)
+		}
+
+		// if this is a reference, value is nil. Ensure reference is not empty
+		if v.IsNil() {
+			if !rf.IsValid() || rf.Type().Kind() != reflect.String || rf.String() == "" {
+				return fmt.Errorf("reference entry is either empty or not string: (k: %s) %v", k, rf)
+			}
+
+			continue
+		}
+
+		if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+			return fmt.Errorf("expecting collection element Value field to point to a struct: (k: %s) %v", k, v)
+		}
+
+		v = v.Elem().FieldByName("Metadata")
+		if !v.IsValid() {
+			return fmt.Errorf("expecting collection element `Value` field to point to a struct with `Metadata` field: (k: %s) %v", k, v)
+		}
+
+		_, ok := v.Interface().(Metadata)
+		if !ok {
+			return fmt.Errorf("expecting `Metadata` field to be of type Metadata: (k: %s) %v", k, v)
+		}
+
+		pp := p
+		pp.Fragment = fmt.Sprintf("%s/%s", p.Fragment, k.String())
+		v.FieldByName("ID").Set(k)
+		v.FieldByName("Path").Set(reflect.ValueOf(pp))
 	}
-	if c2.Headers != nil && c1.Headers == nil {
-		c1.Headers = c2.Headers
-	} else {
-		for k, v := range c2.Headers {
-			if v1, ok := c1.Headers[k]; ok {
-				if v1.Ref == "" && v.Ref != "" {
-					continue // keep the resolved ones
-				}
-			}
-			c1.Headers[k] = v
-		}
-	}
-	if c2.RequestBodies != nil && c1.RequestBodies == nil {
-		c1.RequestBodies = c2.RequestBodies
-	} else {
-		for k, v := range c2.RequestBodies {
-			if v1, ok := c1.RequestBodies[k]; ok {
-				if v1.Ref == "" && v.Ref != "" {
-					continue // keep the resolved ones
-				}
-			}
-			c1.RequestBodies[k] = v
-		}
-	}
-	if c2.Responses != nil && c1.Responses == nil {
-		c1.Responses = c2.Responses
-	} else {
-		for k, v := range c2.Responses {
-			if v1, ok := c1.Responses[k]; ok {
-				if v1.Ref == "" && v.Ref != "" {
-					continue // keep the resolved ones
-				}
-			}
-			c1.Responses[k] = v
-		}
-	}
-	if c2.SecuritySchemes != nil && c1.SecuritySchemes == nil {
-		c1.SecuritySchemes = c2.SecuritySchemes
-	} else {
-		for k, v := range c2.SecuritySchemes {
-			if v1, ok := c1.SecuritySchemes[k]; ok {
-				if v1.Ref == "" && v.Ref != "" {
-					continue // keep the resolved ones
-				}
-			}
-			c1.SecuritySchemes[k] = v
-		}
-	}
-	if c2.Examples != nil && c1.Examples == nil {
-		c1.Examples = c2.Examples
-	} else {
-		for k, v := range c2.Examples {
-			if v1, ok := c1.Examples[k]; ok {
-				if v1.Ref == "" && v.Ref != "" {
-					continue // keep the resolved ones
-				}
-			}
-			c1.Examples[k] = v
-		}
-		for k, v := range c2.Links {
-			if v1, ok := c1.Links[k]; ok {
-				if v1.Ref == "" && v.Ref != "" {
-					continue // keep the resolved ones
-				}
-			}
-			c1.Links[k] = v
-		}
-	}
-	if c2.Callbacks != nil && c1.Callbacks == nil {
-		c1.Callbacks = c2.Callbacks
-	} else {
-		for k, v := range c2.Callbacks {
-			if v1, ok := c1.Callbacks[k]; ok {
-				if v1.Ref == "" && v.Ref != "" {
-					continue // keep the resolved ones
-				}
-			}
-			c1.Callbacks[k] = v
-		}
-	}
-	if c2.Tags != nil && c1.Tags == nil {
-		c1.Tags = c2.Tags
-	} else {
-	outer:
-		for i, v := range c2.Tags {
-			for _, x := range c1.Tags {
-				if v == x {
-					continue outer
-				}
-			}
-			c1.Tags = append(c1.Tags, c2.Tags[i])
-		}
-	}
-	return c1
+
+	return nil
+}
+
+func copyURL(basePath *url.URL) (*url.URL, error) {
+	return url.Parse(basePath.String())
 }
 
 func join(basePath *url.URL, relativePath *url.URL) (*url.URL, error) {
@@ -342,14 +318,15 @@ func (swaggerLoader *SwaggerLoader) resolveComponent(swagger *Swagger, ref strin
 			return nil, "", nil, fmt.Errorf("Error while resolving path: %v", err)
 		}
 
-		if swg2, ok := swaggerLoader.loadedRemoteSchemas[parsedURL.String()]; !ok {
+		key := parsedURL.String()
+		if swg2, ok := swaggerLoader.loadedRemoteSchemas[key]; !ok {
 			if swg2, err = swaggerLoader.LoadSwaggerFromURI(resolvedPath); err != nil {
 				return nil, "", nil, fmt.Errorf("Error while resolving reference '%s': %v", ref, err)
 			}
-			swaggerLoader.loadedRemoteSchemas[parsedURL.String()] = swg2
+			swaggerLoader.loadedRemoteSchemas[key] = swg2
 		}
-		swagger.Components = mergeComponents(swagger.Components, swaggerLoader.loadedRemoteSchemas[parsedURL.String()].Components)
 
+		swagger = swaggerLoader.loadedRemoteSchemas[key]
 		ref = fmt.Sprintf("#%s", fragment)
 		componentPath = resolvedPath
 	}
@@ -363,8 +340,26 @@ func (swaggerLoader *SwaggerLoader) resolveComponent(swagger *Swagger, ref strin
 	}
 	return &swagger.Components, id, componentPath, nil
 }
+func (swaggerLoader *SwaggerLoader) resolved(md Metadata) bool {
+	_, ok := swaggerLoader.visited[md.Path.String()]
+	return ok
+}
+
+func (swaggerLoader *SwaggerLoader) setResolved(md Metadata) {
+	if k := md.Path.String(); k != "" {
+		swaggerLoader.visited[k] = struct{}{}
+	}
+}
 
 func (swaggerLoader *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component *HeaderRef, path *url.URL) error {
+	// Prevent infinite recursion
+	if !component.IsValid() || component.Resolved() {
+		return nil
+	}
+	if component.IsValue() && swaggerLoader.resolved(component.Value.Metadata) {
+		return nil
+	}
+
 	// Resolve ref
 	const prefix = "#/components/headers/"
 	if ref := component.Ref; len(ref) > 0 {
@@ -387,6 +382,9 @@ func (swaggerLoader *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component
 		}
 		component.Value = resolved.Value
 	}
+
+	swaggerLoader.setResolved(component.Value.Metadata)
+
 	value := component.Value
 	if value == nil {
 		return nil
@@ -400,6 +398,14 @@ func (swaggerLoader *SwaggerLoader) resolveHeaderRef(swagger *Swagger, component
 }
 
 func (swaggerLoader *SwaggerLoader) resolveParameterRef(swagger *Swagger, component *ParameterRef, path *url.URL) error {
+	// Prevent infinite recursion
+	if !component.IsValid() || component.Resolved() {
+		return nil
+	}
+	if component.IsValue() && swaggerLoader.resolved(component.Value.Metadata) {
+		return nil
+	}
+
 	// Resolve ref
 	const prefix = "#/components/parameters/"
 	if ref := component.Ref; len(ref) > 0 {
@@ -420,6 +426,9 @@ func (swaggerLoader *SwaggerLoader) resolveParameterRef(swagger *Swagger, compon
 		}
 		component.Value = resolved.Value
 	}
+
+	swaggerLoader.setResolved(component.Value.Metadata)
+
 	value := component.Value
 	if value == nil {
 		return nil
@@ -443,6 +452,13 @@ func (swaggerLoader *SwaggerLoader) resolveParameterRef(swagger *Swagger, compon
 }
 
 func (swaggerLoader *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, component *RequestBodyRef, path *url.URL) error {
+	// Prevent infinite recursion
+	if !component.IsValid() || component.Resolved() {
+		return nil
+	}
+	if component.IsValue() && swaggerLoader.resolved(component.Value.Metadata) {
+		return nil
+	}
 
 	// Resolve ref
 	const prefix = "#/components/requestBodies/"
@@ -464,6 +480,9 @@ func (swaggerLoader *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, comp
 		}
 		component.Value = resolved.Value
 	}
+
+	swaggerLoader.setResolved(component.Value.Metadata)
+
 	value := component.Value
 	if value == nil {
 		return nil
@@ -485,6 +504,13 @@ func (swaggerLoader *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, comp
 }
 
 func (swaggerLoader *SwaggerLoader) resolveResponseRef(swagger *Swagger, component *ResponseRef, path *url.URL) error {
+	// Prevent infinite recursion
+	if !component.IsValid() || component.Resolved() {
+		return nil
+	}
+	if component.IsValue() && swaggerLoader.resolved(component.Value.Metadata) {
+		return nil
+	}
 
 	// Resolve ref
 	const prefix = "#/components/responses/"
@@ -506,6 +532,9 @@ func (swaggerLoader *SwaggerLoader) resolveResponseRef(swagger *Swagger, compone
 		}
 		component.Value = resolved.Value
 	}
+
+	swaggerLoader.setResolved(component.Value.Metadata)
+
 	value := component.Value
 	if value == nil {
 		return nil
@@ -536,6 +565,13 @@ func (swaggerLoader *SwaggerLoader) resolveResponseRef(swagger *Swagger, compone
 }
 
 func (swaggerLoader *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component *SchemaRef, path *url.URL) error {
+	// Prevent infinite recursion
+	if !component.IsValid() || component.Resolved() {
+		return nil
+	}
+	if component.IsValue() && swaggerLoader.resolved(component.Value.Metadata) {
+		return nil
+	}
 
 	// Resolve ref
 	const prefix = "#/components/schemas/"
@@ -557,6 +593,9 @@ func (swaggerLoader *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component
 		}
 		component.Value = resolved.Value
 	}
+
+	swaggerLoader.setResolved(component.Value.Metadata)
+
 	value := component.Value
 	if value == nil {
 		return nil
@@ -603,6 +642,13 @@ func (swaggerLoader *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component
 }
 
 func (swaggerLoader *SwaggerLoader) resolveSecuritySchemeRef(swagger *Swagger, component *SecuritySchemeRef, path *url.URL) error {
+	// Prevent infinite recursion
+	if !component.IsValid() || component.Resolved() {
+		return nil
+	}
+	if component.IsValue() && swaggerLoader.resolved(component.Value.Metadata) {
+		return nil
+	}
 
 	// Resolve ref
 	const prefix = "#/components/securitySchemes/"
@@ -628,6 +674,13 @@ func (swaggerLoader *SwaggerLoader) resolveSecuritySchemeRef(swagger *Swagger, c
 }
 
 func (swaggerLoader *SwaggerLoader) resolveExampleRef(swagger *Swagger, component *ExampleRef, path *url.URL) error {
+	// Prevent infinite recursion
+	if !component.IsValid() || component.Resolved() {
+		return nil
+	}
+	if component.IsValue() && swaggerLoader.resolved(component.Value.Metadata) {
+		return nil
+	}
 
 	const prefix = "#/components/examples/"
 	if ref := component.Ref; len(ref) > 0 {

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -451,10 +451,13 @@ func TestRemoteURLCaching(t *testing.T) {
 	remote, err := url.Parse("http://" + addr + "/test.refcache.openapi.yml")
 	require.NoError(t, err)
 
-	_, err = loader.LoadSwaggerFromURI(remote)
+	doc, err := loader.LoadSwaggerFromURI(remote)
 	require.NoError(t, err)
 
 	require.Contains(t, sfs.hits, "/test.refcache.openapi.yml")
 	require.Contains(t, sfs.hits, "/components.openapi.yml")
-	require.Equal(t, 1, sfs.hits["/components.openapi.yml"], "expcting 1 load of referenced schema")
+	require.Equal(t, 1, sfs.hits["/components.openapi.yml"], "expecting 1 load of referenced schema")
+
+	err = doc.Validate(loader.Context)
+	require.NoError(t, err)
 }

--- a/openapi3/testdata/components2.openapi.yml
+++ b/openapi3/testdata/components2.openapi.yml
@@ -8,3 +8,9 @@ components:
   schemas:
     AnotherName:
       type: string
+
+    NestedRefToComp1Schema:
+      type: object
+      properties:
+        nestedRef1:
+          "$ref": http://localhost:7965/components.openapi.yml#/components/schemas/CustomTestSchema

--- a/openapi3/testdata/components3.openapi.yml
+++ b/openapi3/testdata/components3.openapi.yml
@@ -1,0 +1,13 @@
+---
+openapi: 3.0.0
+info:
+  title: ''
+  version: '1'
+paths: {}
+components:
+  schemas:
+    NestedRefToComp2Schema:
+      type: object
+      properties:
+        nestedRefToComp2:
+          "$ref": http://localhost:7965/components2.openapi.yml#/components/schemas/NestedRefToComp1Schema

--- a/openapi3/testdata/test.refcache.openapi.yml
+++ b/openapi3/testdata/test.refcache.openapi.yml
@@ -15,3 +15,13 @@ components:
           "$ref": http://localhost:7965/components2.openapi.yml#/components/schemas/AnotherName
         ref3:
           "$ref": http://localhost:7965/components.openapi.yml#/components/schemas/Name
+        ref4:
+          "$ref": http://localhost:7965/components.openapi.yml#/components/schemas/CustomTestSchema
+        ref5:
+          "$ref": http://localhost:7965/components2.openapi.yml#/components/schemas/NestedRefToComp1Schema
+        ref6:
+          "$ref": http://localhost:7965/components.openapi.yml#/components/schemas/CustomTestSchema
+        ref7:
+          "$ref": http://localhost:7965/components3.openapi.yml#/components/schemas/NestedRefToComp2Schema
+        ref8:
+          "$ref": http://localhost:7965/components.openapi.yml#/components/schemas/CustomTestSchema


### PR DESCRIPTION
more changes to fix visited schemas and resolving references correctly by adding metadata to select objects (those under Components) 
which is fixed up after loading the swagger document and before resolution takes place. Also fixed the visited cache to use the full path of the resolved object (now also matches $ref values) 

