### PR TITLE
feature: resetting external resolved references

### DIFF
--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -3,30 +3,9 @@ package openapi3
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
-
-type RefOrValue interface {
-	Resolved() bool
-	ResetRef()
-	GetRef() string
-	IsRef() bool
-	IsValue() bool
-	IsValid() bool
-	EmptyRef() bool
-}
-
-func IsExternalRef(rr RefOrValue) bool {
-	return strings.Index(rr.GetRef(), "#") >= 0
-}
-
-func resetResolvedExternalRef(rr RefOrValue) {
-	if rr.IsRef() && IsExternalRef(rr) && rr.Resolved() {
-		rr.ResetRef()
-	}
-}
 
 type CallbackRef struct {
 	Ref   string
@@ -68,7 +47,7 @@ func (value ExampleRef) IsValue() bool  { return value.Ref == "" && value.Value 
 func (value ExampleRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value ExampleRef) EmptyRef() bool { return value.Ref == "" }
 func (value ExampleRef) GetRef() string { return value.Ref }
-func (value *ExampleRef) ResetRef()     { value.Ref = "" }
+func (value *ExampleRef) ClearRef()     { value.Ref = "" }
 
 func (value *ExampleRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -97,7 +76,7 @@ func (value HeaderRef) IsValue() bool  { return value.Ref == "" && value.Value !
 func (value HeaderRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value HeaderRef) EmptyRef() bool { return value.Ref == "" }
 func (value HeaderRef) GetRef() string { return value.Ref }
-func (value *HeaderRef) ResetRef()     { value.Ref = "" }
+func (value *HeaderRef) ClearRef()     { value.Ref = "" }
 
 func (value *HeaderRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -130,7 +109,7 @@ func (value LinkRef) IsValue() bool  { return value.Ref == "" && value.Value != 
 func (value LinkRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value LinkRef) EmptyRef() bool { return value.Ref == "" }
 func (value LinkRef) GetRef() string { return value.Ref }
-func (value *LinkRef) ResetRef()     { value.Ref = "" }
+func (value *LinkRef) ClearRef()     { value.Ref = "" }
 
 func (value *LinkRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -163,7 +142,7 @@ func (value ParameterRef) IsValue() bool  { return value.Ref == "" && value.Valu
 func (value ParameterRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value ParameterRef) EmptyRef() bool { return value.Ref == "" }
 func (value ParameterRef) GetRef() string { return value.Ref }
-func (value *ParameterRef) ResetRef()     { value.Ref = "" }
+func (value *ParameterRef) ClearRef()     { value.Ref = "" }
 
 func (value *ParameterRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -196,7 +175,7 @@ func (value ResponseRef) IsValue() bool  { return value.Ref == "" && value.Value
 func (value ResponseRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value ResponseRef) EmptyRef() bool { return value.Ref == "" }
 func (value ResponseRef) GetRef() string { return value.Ref }
-func (value *ResponseRef) ResetRef()     { value.Ref = "" }
+func (value *ResponseRef) ClearRef()     { value.Ref = "" }
 
 func (value *ResponseRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -229,7 +208,7 @@ func (value RequestBodyRef) IsValue() bool  { return value.Ref == "" && value.Va
 func (value RequestBodyRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value RequestBodyRef) EmptyRef() bool { return value.Ref == "" }
 func (value RequestBodyRef) GetRef() string { return value.Ref }
-func (value *RequestBodyRef) ResetRef()     { value.Ref = "" }
+func (value *RequestBodyRef) ClearRef()     { value.Ref = "" }
 
 func (value *RequestBodyRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -262,7 +241,7 @@ func (value SchemaRef) IsValue() bool  { return value.Ref == "" && value.Value !
 func (value SchemaRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value SchemaRef) EmptyRef() bool { return value.Ref == "" }
 func (value SchemaRef) GetRef() string { return value.Ref }
-func (value *SchemaRef) ResetRef()     { value.Ref = "" }
+func (value *SchemaRef) ClearRef()     { value.Ref = "" }
 
 func NewSchemaRef(ref string, value *Schema) *SchemaRef {
 	return &SchemaRef{
@@ -302,7 +281,7 @@ func (value SecuritySchemeRef) IsValue() bool  { return value.Ref == "" && value
 func (value SecuritySchemeRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value SecuritySchemeRef) EmptyRef() bool { return value.Ref == "" }
 func (value SecuritySchemeRef) GetRef() string { return value.Ref }
-func (value *SecuritySchemeRef) ResetRef()     { value.Ref = "" }
+func (value *SecuritySchemeRef) ClearRef()     { value.Ref = "" }
 
 func (value *SecuritySchemeRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -3,9 +3,30 @@ package openapi3
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
+
+type RefOrValue interface {
+	Resolved() bool
+	ResetRef()
+	GetRef() string
+	IsRef() bool
+	IsValue() bool
+	IsValid() bool
+	EmptyRef() bool
+}
+
+func IsExternalRef(rr RefOrValue) bool {
+	return strings.Index(rr.GetRef(), "#") >= 0
+}
+
+func resetResolvedExternalRef(rr RefOrValue) {
+	if rr.IsRef() && IsExternalRef(rr) && rr.Resolved() {
+		rr.ResetRef()
+	}
+}
 
 type CallbackRef struct {
 	Ref   string
@@ -41,11 +62,13 @@ func (value ExampleRef) String() string {
 	return fmt.Sprintf("%s:ExampleRef", value.Ref)
 }
 
-func (value ExampleRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value ExampleRef) Resolved() bool { return value.Ref != "" && value.Value != nil }
 func (value ExampleRef) IsRef() bool    { return value.Ref != "" }
 func (value ExampleRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
 func (value ExampleRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value ExampleRef) EmptyRef() bool { return value.Ref == "" }
+func (value ExampleRef) GetRef() string { return value.Ref }
+func (value *ExampleRef) ResetRef()     { value.Ref = "" }
 
 func (value *ExampleRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -68,11 +91,13 @@ func (value HeaderRef) String() string {
 	return fmt.Sprintf("%s:HeaderRef", value.Ref)
 }
 
-func (value HeaderRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value HeaderRef) Resolved() bool { return value.Ref != "" && value.Value != nil }
 func (value HeaderRef) IsRef() bool    { return value.Ref != "" }
 func (value HeaderRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
 func (value HeaderRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value HeaderRef) EmptyRef() bool { return value.Ref == "" }
+func (value HeaderRef) GetRef() string { return value.Ref }
+func (value *HeaderRef) ResetRef()     { value.Ref = "" }
 
 func (value *HeaderRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -99,11 +124,13 @@ func (value LinkRef) String() string {
 	return fmt.Sprintf("%s:LinkRef", value.Ref)
 }
 
-func (value LinkRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value LinkRef) Resolved() bool { return value.Ref != "" && value.Value != nil }
 func (value LinkRef) IsRef() bool    { return value.Ref != "" }
 func (value LinkRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
 func (value LinkRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value LinkRef) EmptyRef() bool { return value.Ref == "" }
+func (value LinkRef) GetRef() string { return value.Ref }
+func (value *LinkRef) ResetRef()     { value.Ref = "" }
 
 func (value *LinkRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -130,11 +157,13 @@ func (value ParameterRef) String() string {
 	return fmt.Sprintf("%s:ParameterRef", value.Ref)
 }
 
-func (value ParameterRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value ParameterRef) Resolved() bool { return value.Ref != "" && value.Value != nil }
 func (value ParameterRef) IsRef() bool    { return value.Ref != "" }
 func (value ParameterRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
 func (value ParameterRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value ParameterRef) EmptyRef() bool { return value.Ref == "" }
+func (value ParameterRef) GetRef() string { return value.Ref }
+func (value *ParameterRef) ResetRef()     { value.Ref = "" }
 
 func (value *ParameterRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -161,11 +190,13 @@ func (value ResponseRef) String() string {
 	return fmt.Sprintf("%s:ResponseRef", value.Ref)
 }
 
-func (value ResponseRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value ResponseRef) Resolved() bool { return value.Ref != "" && value.Value != nil }
 func (value ResponseRef) IsRef() bool    { return value.Ref != "" }
 func (value ResponseRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
 func (value ResponseRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value ResponseRef) EmptyRef() bool { return value.Ref == "" }
+func (value ResponseRef) GetRef() string { return value.Ref }
+func (value *ResponseRef) ResetRef()     { value.Ref = "" }
 
 func (value *ResponseRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -192,11 +223,13 @@ func (value RequestBodyRef) String() string {
 	return fmt.Sprintf("%s:RequestBodyRef", value.Ref)
 }
 
-func (value RequestBodyRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value RequestBodyRef) Resolved() bool { return value.Ref != "" && value.Value != nil }
 func (value RequestBodyRef) IsRef() bool    { return value.Ref != "" }
 func (value RequestBodyRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
 func (value RequestBodyRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value RequestBodyRef) EmptyRef() bool { return value.Ref == "" }
+func (value RequestBodyRef) GetRef() string { return value.Ref }
+func (value *RequestBodyRef) ResetRef()     { value.Ref = "" }
 
 func (value *RequestBodyRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -223,11 +256,13 @@ func (value SchemaRef) String() string {
 	return fmt.Sprintf("%s:SchemaRef", value.Ref)
 }
 
-func (value SchemaRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value SchemaRef) Resolved() bool { return value.Ref != "" && value.Value != nil }
 func (value SchemaRef) IsRef() bool    { return value.Ref != "" }
 func (value SchemaRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
 func (value SchemaRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value SchemaRef) EmptyRef() bool { return value.Ref == "" }
+func (value SchemaRef) GetRef() string { return value.Ref }
+func (value *SchemaRef) ResetRef()     { value.Ref = "" }
 
 func NewSchemaRef(ref string, value *Schema) *SchemaRef {
 	return &SchemaRef{
@@ -261,11 +296,13 @@ func (value SecuritySchemeRef) String() string {
 	return fmt.Sprintf("%s:SecuritySchemeRef", value.Ref)
 }
 
-func (value SecuritySchemeRef) Resolved() bool { return !value.EmptyRef() && value.Value != nil }
+func (value SecuritySchemeRef) Resolved() bool { return value.Ref != "" && value.Value != nil }
 func (value SecuritySchemeRef) IsRef() bool    { return value.Ref != "" }
 func (value SecuritySchemeRef) IsValue() bool  { return value.Ref == "" && value.Value != nil }
 func (value SecuritySchemeRef) IsValid() bool  { return value.Ref != "" || value.Value != nil }
 func (value SecuritySchemeRef) EmptyRef() bool { return value.Ref == "" }
+func (value SecuritySchemeRef) GetRef() string { return value.Ref }
+func (value *SecuritySchemeRef) ResetRef()     { value.Ref = "" }
 
 func (value *SecuritySchemeRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)

--- a/openapi3/swagger_utils.go
+++ b/openapi3/swagger_utils.go
@@ -1,0 +1,49 @@
+package openapi3
+
+import "reflect"
+
+// ResetResolvedExternalRefs Recursively iterate over the swagger structure, resetting <Type>Ref structs where
+// the reference is remote and was resolved
+func ResetResolvedExternalRefs(swagger *Swagger) {
+	resetExternalRef(reflect.ValueOf(swagger))
+}
+
+func resetExternalRef(c reflect.Value) {
+	switch c.Kind() {
+	// If it is a struct, check if it's the desired type first before drilling into fields
+	// Further if this is a <Type>Ref struct, reset the reference if it's remote and resolved
+	case reflect.Struct:
+		if c.CanAddr() {
+			rov, ok := c.Addr().Interface().(RefOrValue)
+			if ok {
+				resetResolvedExternalRef(rov)
+			}
+		}
+		for i := 0; i < c.NumField(); i += 1 {
+			resetExternalRef(c.Field(i))
+		}
+
+	// If it is a pointer or interface we need to unwrap and call once again
+	case reflect.Interface, reflect.Ptr:
+		c2 := c.Elem()
+		if c2.IsValid() {
+			resetExternalRef(c2)
+		}
+
+	// If it is a slice we iterate over each each element
+	case reflect.Slice:
+		for i := 0; i < c.Len(); i += 1 {
+			resetExternalRef(c.Index(i))
+		}
+
+	// If it is a map we iterate over each of the key,value pairs
+	case reflect.Map:
+		mi := c.MapRange()
+		for mi.Next() {
+			resetExternalRef(mi.Value())
+		}
+
+	// And everything else will simply be ignored
+	default:
+	}
+}

--- a/openapi3/swagger_utils_test.go
+++ b/openapi3/swagger_utils_test.go
@@ -1,0 +1,33 @@
+package openapi3_test
+
+import (
+	"net/http"
+
+	"net/url"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResettingExternalRefs(t *testing.T) {
+
+	cs := startTestServer(http.Dir("testdata"))
+	defer cs()
+
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	remote, err := url.Parse("http://" + addr + "/test.refcache.openapi.yml")
+	require.NoError(t, err)
+
+	doc, err := loader.LoadSwaggerFromURI(remote)
+	require.NoError(t, err)
+
+	openapi3.ResetResolvedExternalRefs(doc)
+
+	for _, s := range []string{"ref1", "ref2", "ref3", "ref4", "ref5", "ref6"} {
+		sr := doc.Components.Schemas["AnotherTestSchema"].Value.Properties[s]
+		require.True(t, sr.IsValue())
+		require.False(t, sr.Resolved())
+	}
+}


### PR DESCRIPTION
This PR adds a utility function that recursively resets all references in swagger definitions.
This is useful so that the openapi3filter package can successfully validate requests which use
schemas that include references. (no resolution is done at runtime by the validator and all validation
functions use the Value member of a <Type>Ref.

So for example, for a SchemaRef (where most validation apply), which is defined as:
```
type SchemaRef struct {
   Ref string
   Value *Schema
}
```
when used at runtime in a request body, would result in an partial object looking like:
```
...
   "get" : Operation {
        RequestBody {
           Content: {
               "application/json":  {
                   ...
                   Schema SchemaRef {
                       Ref:  "#/some/path"
                       Value: Schema {                                      <----------------
                           ...
                       }
```
The marked `Value` object is what being used by the validator (so `Operation.RequestBody.Contents["application/json"].Schema.Value`)

The validation will fail if the original schema definition was marshaled into JSON before being used by the validator as the JSON marshaller prefers the `Ref` property rather than the underlying object pointed to by the `Value` property
