### PR TITLE
Added Constructor options.

### DIFF
--- a/openapi3/swagger_loader_relative_refs_test.go
+++ b/openapi3/swagger_loader_relative_refs_test.go
@@ -213,8 +213,7 @@ func TestLoadFromDataWithExternalRef(t *testing.T) {
 		t.Logf("testcase '%s'", td.name)
 
 		spec := []byte(fmt.Sprintf(td.contentTemplate, "components.openapi.json"))
-		loader := openapi3.NewSwaggerLoader()
-		loader.IsExternalRefsAllowed = true
+		loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 		swagger, err := loader.LoadSwaggerFromDataWithPath(spec, &url.URL{Path: "testdata/testfilename.openapi.json"})
 		require.NoError(t, err)
 		td.testFunc(t, swagger)
@@ -226,8 +225,7 @@ func TestLoadFromDataWithExternalRefResponseError(t *testing.T) {
 		t.Logf("testcase '%s'", td.name)
 
 		spec := []byte(fmt.Sprintf(td.contentTemplate, "components.openapi.json"))
-		loader := openapi3.NewSwaggerLoader()
-		loader.IsExternalRefsAllowed = true
+		loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 		swagger, err := loader.LoadSwaggerFromDataWithPath(spec, &url.URL{Path: "testdata/testfilename.openapi.json"})
 		require.EqualError(t, err, *td.errorMessage)
 		td.testFunc(t, swagger)
@@ -239,8 +237,7 @@ func TestLoadFromDataWithExternalNestedRef(t *testing.T) {
 		t.Logf("testcase '%s'", td.name)
 
 		spec := []byte(fmt.Sprintf(td.contentTemplate, "nesteddir/nestedcomponents.openapi.json"))
-		loader := openapi3.NewSwaggerLoader()
-		loader.IsExternalRefsAllowed = true
+		loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 		swagger, err := loader.LoadSwaggerFromDataWithPath(spec, &url.URL{Path: "testdata/testfilename.openapi.json"})
 		require.NoError(t, err)
 		td.testFunc(t, swagger)

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -184,8 +184,7 @@ func TestResolveSchemaExternalRef(t *testing.T) {
 			},
 		},
 	}
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 	loader.LoadSwaggerFromURIFunc = multipleSourceLoader.LoadSwaggerFromURI
 
 	doc, err := loader.LoadSwaggerFromURI(rootLocation)
@@ -310,8 +309,7 @@ func TestLoadFromRemoteURL(t *testing.T) {
 	cs := startTestServer(http.Dir("testdata"))
 	defer cs()
 
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 	remote, err := url.Parse("http://" + addr + "/test.openapi.json")
 	require.NoError(t, err)
 
@@ -322,8 +320,7 @@ func TestLoadFromRemoteURL(t *testing.T) {
 }
 
 func TestLoadFileWithExternalSchemaRef(t *testing.T) {
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 	swagger, err := loader.LoadSwaggerFromFile("testdata/testref.openapi.json")
 	require.NoError(t, err)
 
@@ -404,8 +401,7 @@ func TestLoadFromDataWithExternalRequestResponseHeaderExternalRef(t *testing.T) 
 	cs := startTestServer(http.Dir("testdata"))
 	defer cs()
 
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 	swagger, err := loader.LoadSwaggerFromDataWithPath(spec, &url.URL{Path: "testdata/testfilename.openapi.json"})
 	require.NoError(t, err)
 
@@ -414,8 +410,7 @@ func TestLoadFromDataWithExternalRequestResponseHeaderExternalRef(t *testing.T) 
 }
 
 func TestLoadYamlFile(t *testing.T) {
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 	swagger, err := loader.LoadSwaggerFromFile("testdata/test.openapi.yml")
 	require.NoError(t, err)
 
@@ -423,8 +418,7 @@ func TestLoadYamlFile(t *testing.T) {
 }
 
 func TestLoadYamlFileWithExternalSchemaRef(t *testing.T) {
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 	swagger, err := loader.LoadSwaggerFromFile("testdata/testref.openapi.yml")
 	require.NoError(t, err)
 
@@ -447,8 +441,7 @@ func TestRemoteURLCaching(t *testing.T) {
 	cs := startTestServer(sfs)
 	defer cs()
 
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 	remote, err := url.Parse("http://" + addr + "/test.refcache.openapi.yml")
 	require.NoError(t, err)
 
@@ -461,4 +454,29 @@ func TestRemoteURLCaching(t *testing.T) {
 
 	err = doc.Validate(loader.Context)
 	require.NoError(t, err)
+}
+
+func TestLoaderOptions(t *testing.T) {
+	sl := openapi3.NewSwaggerLoader()
+	require.Nil(t, sl.LoadSwaggerFromURIFunc)
+	require.False(t, sl.IsExternalRefsAllowed)
+	require.False(t, sl.ClearResolvedRefs)
+	require.True(t, sl.SetMetadata) // default is true
+
+	vc := false
+	v := func(loader *openapi3.SwaggerLoader, location *url.URL) (*openapi3.Swagger, error) {
+		vc = true
+		return nil, nil
+	}
+
+	sl = openapi3.NewSwaggerLoader(openapi3.WithClearResolvedRefs(true),
+		openapi3.WithSetMetadata(false), openapi3.WithAllowExternalRefs(true),
+		openapi3.WithURILoader(v))
+	require.NotNil(t, sl.LoadSwaggerFromURIFunc)
+	require.True(t, sl.IsExternalRefsAllowed)
+	require.True(t, sl.ClearResolvedRefs)
+	require.False(t, sl.SetMetadata)
+
+	_, _ = sl.LoadSwaggerFromURIFunc(nil, nil)
+	require.True(t, vc)
 }

--- a/openapi3/swagger_utils.go
+++ b/openapi3/swagger_utils.go
@@ -22,9 +22,9 @@ func clearResolvedExternalRef(rr RefOrValue) {
 	}
 }
 
-// ResetResolvedExternalRefs Recursively iterate over the swagger structure, resetting <Type>Ref structs where
+// ClearResolvedExternalRefs Recursively iterate over the swagger structure, resetting <Type>Ref structs where
 // the reference is remote and was resolved
-func ResetResolvedExternalRefs(swagger *Swagger) {
+func ClearResolvedExternalRefs(swagger *Swagger) {
 	resetExternalRef(reflect.ValueOf(swagger))
 }
 

--- a/openapi3/swagger_utils_test.go
+++ b/openapi3/swagger_utils_test.go
@@ -15,15 +15,14 @@ func TestResettingExternalRefs(t *testing.T) {
 	cs := startTestServer(http.Dir("testdata"))
 	defer cs()
 
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := openapi3.NewSwaggerLoader(openapi3.WithAllowExternalRefs(true))
 	remote, err := url.Parse("http://" + addr + "/test.refcache.openapi.yml")
 	require.NoError(t, err)
 
 	doc, err := loader.LoadSwaggerFromURI(remote)
 	require.NoError(t, err)
 
-	openapi3.ResetResolvedExternalRefs(doc)
+	openapi3.ClearResolvedExternalRefs(doc)
 
 	for _, s := range []string{"ref1", "ref2", "ref3", "ref4", "ref5", "ref6"} {
 		sr := doc.Components.Schemas["AnotherTestSchema"].Value.Properties[s]


### PR DESCRIPTION
Added functional options to SwaggerLoader to allow setting during construction time

Setting options should now be more idiomatic

Note: options are still public - something I hope to change, it was done in keeping with the state of IsExternalRefsAllowed and code that uses that. I would also like to create an Options struct that 
is separate from the loader. Later though